### PR TITLE
changing to linkedhashmap

### DIFF
--- a/src/main/java/org/json/simple/JSONObject.java
+++ b/src/main/java/org/json/simple/JSONObject.java
@@ -16,7 +16,7 @@ import java.util.Map;
  * 
  * @author FangYidong<fangyidong@yahoo.com.cn>
  */
-public class JSONObject extends HashMap implements Map, JSONAware, JSONStreamAware{
+public class JSONObject extends LinkedHashMap implements Map, JSONAware, JSONStreamAware{
 	
 	private static final long serialVersionUID = -503443796854799292L;
 	


### PR DESCRIPTION
I have a need for the JSONObject order to be preserved. Extending LinkedHashMap instead of HashMap fixes my issue.